### PR TITLE
Add setting to enable placing in inventory when punched

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -19,7 +19,9 @@ local settings = {
 	-- Ability to punch the motorbike to kick the rider
 	kick = true,
 	-- Enable custom plates, requires "signs" mod
-	custom_plates = true
+	custom_plates = true,
+	-- Bike is be placed directly in inventory when punched
+	punch_inv = false,
 }
 for setting, default in pairs(settings) do
 	local value = minetest.settings:get("motorbike." .. setting)
@@ -96,9 +98,21 @@ for _, colour in pairs(bikelist) do
 			end
 			if not self.driver then
 				if biker.breakable then
-					local pos = self.object:get_pos()
-					local item = minetest.add_item(pos, self.drop)
-					if item then
+					if not settings.punch_inv then
+						local pos = self.object:get_pos()
+						local item = minetest.add_item(pos, self.drop)
+						if item then
+							self.object:remove()
+							if self.plate then self.plate:remove() end
+						end
+					else
+						local stack = ItemStack(self.drop)
+						local pinv = puncher:get_inventory()
+						if not pinv:room_for_item("main", stack) then
+							core.chat_send_player(puncher:get_player_name(), "You do not have room in your inventory")
+							return
+						end
+						pinv:add_item("main", stack)
 						self.object:remove()
 						if self.plate then self.plate:remove() end
 					end

--- a/init.lua
+++ b/init.lua
@@ -21,7 +21,7 @@ local settings = {
 	-- Enable custom plates, requires "signs" mod
 	custom_plates = true,
 	-- Bike is be placed directly in inventory when punched
-	punch_inv = false,
+	punch_inv = true,
 }
 for setting, default in pairs(settings) do
 	local value = minetest.settings:get("motorbike." .. setting)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,3 @@
+
+# If enabled, bike is placed in inventory when punched.
+motorbike.punch_inv (Punch places in inventory) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,3 +1,33 @@
 
+# Turning speed of bike, 1 is instant.
+motorbike.turn_power (Turning speed) float 0.07
+
+# Top speed the bike can go.
+motorbike.max_speed (Top speed) float 17
+
+# Top speed in reverse.
+motorbike.max_reverse (Top speed reverse) float 5
+
+# Acceleration.
+motorbike.acceleration (Acceleration) float 1.5
+
+# Braking power.
+motorbike.braking (Braking power) float 5
+
+# Step height.
+motorbike.stepheight (Step height) float 1.3
+
+# Whether the bike is breakable.
+motorbike.breakable (Breakable) bool true
+
+# Same as max_speed but on nodes like dirt, sand, gravel ect.
+motorbike.crumbly_spd (Top speed crumbly) float 11
+
+# Ability to punch the motorbike to kick the rider.
+motorbike.kick (Punch kicks rider) bool true
+
+# Enable custom plates, requires "signs" mod.
+motorbike.custom_plates (Custom plates) bool true
+
 # If enabled, bike is placed in inventory when punched.
 motorbike.punch_inv (Punch places in inventory) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -30,4 +30,4 @@ motorbike.kick (Punch kicks rider) bool true
 motorbike.custom_plates (Custom plates) bool true
 
 # If enabled, bike is placed in inventory when punched.
-motorbike.punch_inv (Punch places in inventory) bool false
+motorbike.punch_inv (Punch places in inventory) bool true


### PR DESCRIPTION
Adds setting `motorbike.punch_inv`:
- if enabled, bike is placed directly into inventory when punched
- default: disabled