### PR TITLE
Fixed audio errors for bike reverse

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -254,7 +254,7 @@ function def.play_sounds(self, dtime)
 		self.timer = self.timer + dtime
 		if self.timer > 0.1 then
             local s = biker.max_speed / 2
-			local rpm = self.vel/s
+			local rpm = math.abs(self.vel/s)
 
 			minetest.sound_play("motoengine", {
                 max_hear_distance = 48,


### PR DESCRIPTION
Minetest 5.8.0
Fixed issue where motorbike engine sound is not ramping up and down correctly when going in reverse. 

Errors in minetest log: 
`WARNING[OpenALSoundManager]: OpenALSoundManager::playSoundGeneric: Illegal pitch value: 0`

Diagnosis:
When `sound_play` is called, pitch parameter is getting sent a negative value when motorbike is going in reverse.

Fix applied:
Make sure the local variable `rpm` is mathematically absolute.